### PR TITLE
fix(frontend): improve Mermaid rendering and preview controls

### DIFF
--- a/frontend/src/components/NormalizedConversation/Markdown.test.tsx
+++ b/frontend/src/components/NormalizedConversation/Markdown.test.tsx
@@ -602,16 +602,41 @@ $$`);
       )
     );
 
-    const image = await screen.findByRole('img', { name: /Mermaid/ });
-    expect(image).toHaveAttribute(
-      'src',
-      expect.stringContaining('data:image/svg+xml;charset=utf-8,')
-    );
+    const diagram = await screen.findByRole('img', { name: /Mermaid/ });
+    expect(diagram.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '\u653e\u5927' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '\u7f29\u5c0f' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '\u9002\u5e94' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '\u5168\u5c4f' })).toBeInTheDocument();
     expect(screen.queryByText('mermaid')).not.toBeInTheDocument();
   });
 
+  it('normalizes legacy graph syntax before rendering Mermaid diagrams', async () => {
+    mermaidMock.render
+      .mockRejectedValueOnce(new Error('parse error'))
+      .mockResolvedValueOnce({
+        svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Mock diagram</text></svg>',
+      });
+
+    renderMarkdown(
+      '```mermaid\ngraph TB\nsubgraph 基础层\nBM[BaseModel<br/>- ID, CreatedAt]\nend\n```'
+    );
+
+    await waitFor(() => expect(mermaidMock.render).toHaveBeenCalledTimes(2));
+    expect(mermaidMock.render).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^mermaid-/),
+      expect.stringContaining('flowchart TB')
+    );
+    expect(mermaidMock.render).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^mermaid-/),
+      expect.stringContaining('subgraph 基础层["基础层"]')
+    );
+  });
+
   it('keeps Mermaid source inspectable when rendering fails', async () => {
-    mermaidMock.render.mockRejectedValueOnce(new Error('bad diagram'));
+    mermaidMock.render.mockRejectedValue(new Error('bad diagram'));
 
     renderMarkdown('```mermaid\ngraph TD\nA-->B\n```');
 

--- a/frontend/src/components/NormalizedConversation/MermaidDiagram.tsx
+++ b/frontend/src/components/NormalizedConversation/MermaidDiagram.tsx
@@ -1,138 +1,19 @@
-import { memo, useEffect, useId, useMemo, useState } from 'react';
+import { memo } from 'react';
+import { useMermaidDiagram } from '@/hooks/useMermaidDiagram';
+import { MermaidDiagramViewer } from './MermaidDiagramViewer';
 
 type MermaidDiagramProps = {
   value: string;
 };
 
-type RenderState =
-  | { status: 'loading' }
-  | { status: 'ready'; src: string }
-  | { status: 'error'; message: string };
-
-function hashString(value: string): string {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash << 5) - hash + value.charCodeAt(index);
-    hash |= 0;
-  }
-  return Math.abs(hash).toString(36);
-}
-
-function sanitizeDomId(value: string): string {
-  return value.replace(/[^a-zA-Z0-9_-]/g, '') || 'diagram';
-}
-
-function svgToDataUrl(svg: string): string {
-  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-}
-
-// mermaid.initialize sets global singleton config; only re-run it when the theme
-// actually changes rather than on every diagram value update.
-let lastMermaidTheme: 'default' | 'dark' | null = null;
-
-async function loadMermaid(theme: 'default' | 'dark') {
-  const { default: mermaid } = await import('mermaid');
-  if (lastMermaidTheme !== theme) {
-    mermaid.initialize({
-      startOnLoad: false,
-      securityLevel: 'strict',
-      theme,
-      fontFamily:
-        'Noto Sans SC Variable, Source Han Sans SC, Source Han Sans CN, Noto Sans CJK SC, Noto Sans SC, 思源黑体, sans-serif',
-    });
-    lastMermaidTheme = theme;
-  }
-  return mermaid;
-}
-
-function getMermaidTheme(): 'default' | 'dark' {
-  if (typeof document === 'undefined') {
-    return 'default';
-  }
-
-  return document.documentElement.classList.contains('dark')
-    ? 'dark'
-    : 'default';
-}
-
-function useMermaidTheme(): 'default' | 'dark' {
-  const [theme, setTheme] = useState(getMermaidTheme);
-
-  useEffect(() => {
-    if (
-      typeof document === 'undefined' ||
-      typeof MutationObserver === 'undefined'
-    ) {
-      return undefined;
-    }
-
-    const root = document.documentElement;
-    const observer = new MutationObserver(() => {
-      setTheme(getMermaidTheme());
-    });
-
-    observer.observe(root, {
-      attributes: true,
-      attributeFilter: ['class'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  return theme;
-}
-
 export const MermaidDiagram = memo(function MermaidDiagram({
   value,
 }: MermaidDiagramProps) {
-  const reactId = useId();
-  const theme = useMermaidTheme();
-  const diagramId = useMemo(
-    () => `mermaid-${sanitizeDomId(reactId)}-${hashString(value)}`,
-    [reactId, value]
-  );
-  const [renderState, setRenderState] = useState<RenderState>({
-    status: 'loading',
-  });
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function renderDiagram() {
-      setRenderState((current) =>
-        current.status === 'ready' ? current : { status: 'loading' }
-      );
-
-      try {
-        const mermaid = await loadMermaid(theme);
-        const { svg } = await mermaid.render(diagramId, value);
-
-        if (!cancelled) {
-          setRenderState({ status: 'ready', src: svgToDataUrl(svg) });
-        }
-      } catch (error) {
-        if (!cancelled) {
-          setRenderState({
-            status: 'error',
-            message:
-              error instanceof Error && error.message
-                ? error.message
-                : '\u672a\u77e5\u7684 Mermaid \u6e32\u67d3\u9519\u8bef',
-          });
-        }
-      }
-    }
-
-    void renderDiagram();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [diagramId, theme, value]);
+  const state = useMermaidDiagram(value);
 
   return (
     <figure className="conv-md-mermaid">
-      {renderState.status === 'loading' ? (
+      {state.status === 'loading' ? (
         <div
           className="conv-md-mermaid-status"
           role="status"
@@ -142,23 +23,16 @@ export const MermaidDiagram = memo(function MermaidDiagram({
         </div>
       ) : null}
 
-      {renderState.status === 'ready' ? (
-        <img
-          className="conv-md-mermaid-image"
-          src={renderState.src}
-          alt={'Mermaid \u56fe\u8868'}
-          loading="lazy"
-        />
+      {state.status === 'ready' ? (
+        <MermaidDiagramViewer svg={state.svg} />
       ) : null}
 
-      {renderState.status === 'error' ? (
+      {state.status === 'error' ? (
         <div className="conv-md-mermaid-error" role="alert">
           <div className="conv-md-mermaid-error-title">
             {'\u56fe\u8868\u6e32\u67d3\u5931\u8d25'}
           </div>
-          <div className="conv-md-mermaid-error-detail">
-            {renderState.message}
-          </div>
+          <div className="conv-md-mermaid-error-detail">{state.message}</div>
           <pre className="conv-md-mermaid-source">
             <code>{value}</code>
           </pre>

--- a/frontend/src/components/NormalizedConversation/MermaidDiagramViewer.tsx
+++ b/frontend/src/components/NormalizedConversation/MermaidDiagramViewer.tsx
@@ -1,0 +1,78 @@
+import { memo, useLayoutEffect, useRef, useState } from 'react';
+import { ZoomableViewport } from '@/components/ui/zoomable-viewport';
+import type { ViewportSize } from '@/hooks/useZoomableViewport';
+
+type MermaidDiagramViewerProps = {
+  svg: string;
+};
+
+function measureSvgSize(svg: SVGSVGElement): ViewportSize {
+  const viewBox = svg.viewBox?.baseVal;
+  if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
+    return { width: viewBox.width, height: viewBox.height };
+  }
+
+  try {
+    const bbox = svg.getBBox();
+    if (bbox.width > 0 && bbox.height > 0) {
+      return { width: bbox.width, height: bbox.height };
+    }
+  } catch {
+    // getBBox can throw before the SVG is fully laid out.
+  }
+
+  const rect = svg.getBoundingClientRect();
+  return {
+    width: rect.width || 640,
+    height: rect.height || 360,
+  };
+}
+
+export const MermaidDiagramViewer = memo(function MermaidDiagramViewer({
+  svg,
+}: MermaidDiagramViewerProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [contentSize, setContentSize] = useState<ViewportSize>({
+    width: 0,
+    height: 0,
+  });
+
+  useLayoutEffect(() => {
+    const svgElement = contentRef.current?.querySelector('svg');
+    if (!svgElement) {
+      setContentSize({ width: 0, height: 0 });
+      return undefined;
+    }
+
+    const updateSize = () => {
+      setContentSize(measureSvgSize(svgElement));
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(svgElement);
+    return () => observer.disconnect();
+  }, [svg]);
+
+  return (
+    <ZoomableViewport
+      contentSize={contentSize}
+      options={{ resetKey: svg }}
+      ariaLabel={'Mermaid \u56fe\u8868'}
+      className="conv-md-mermaid-viewer"
+      viewportClassName="conv-md-mermaid-viewport"
+      surfaceClassName="conv-md-mermaid-surface"
+    >
+      <div
+        ref={contentRef}
+        className="conv-md-mermaid-svg"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    </ZoomableViewport>
+  );
+});

--- a/frontend/src/components/ui/zoomable-viewport.tsx
+++ b/frontend/src/components/ui/zoomable-viewport.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  Maximize2,
+  Minimize2,
+  Minus,
+  Move,
+  Plus,
+  ScanSearch,
+  Undo2,
+} from 'lucide-react';
+import {
+  useZoomableViewport,
+  type ViewportSize,
+  type ZoomableViewportOptions,
+} from '@/hooks/useZoomableViewport';
+import { cn } from '@/lib/utils';
+
+type ZoomableViewportProps = {
+  contentSize: ViewportSize;
+  children: ReactNode;
+  className?: string;
+  viewportClassName?: string;
+  surfaceClassName?: string;
+  ariaLabel: string;
+  options?: ZoomableViewportOptions;
+};
+
+export function ZoomableViewport({
+  contentSize,
+  children,
+  className,
+  viewportClassName,
+  surfaceClassName,
+  ariaLabel,
+  options,
+}: ZoomableViewportProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const {
+    viewportRef,
+    fittedSize,
+    scale,
+    offset,
+    canPan,
+    isDragging,
+    zoomPercent,
+    zoomIn,
+    zoomOut,
+    zoomToActualSize,
+    resetView,
+    toggleFitOrZoom,
+    handleWheel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerEnd,
+    minScale,
+    maxScale,
+  } = useZoomableViewport(contentSize, options);
+
+  useEffect(() => {
+    const onFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === rootRef.current);
+    };
+
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = async () => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    if (document.fullscreenElement === root) {
+      await document.exitFullscreen();
+      return;
+    }
+
+    await root.requestFullscreen();
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn('conv-zoomable-viewport', className)}
+      data-fullscreen={isFullscreen ? 'true' : 'false'}
+    >
+      <div className="conv-zoomable-viewport__toolbar" aria-hidden={false}>
+        <button
+          type="button"
+          className="conv-zoomable-viewport__button"
+          onClick={zoomOut}
+          disabled={scale <= minScale}
+          aria-label={'\u7f29\u5c0f'}
+          title={'\u7f29\u5c0f'}
+        >
+          <Minus className="h-4 w-4" />
+        </button>
+        <span className="conv-zoomable-viewport__zoom">{zoomPercent}%</span>
+        <button
+          type="button"
+          className="conv-zoomable-viewport__button"
+          onClick={zoomIn}
+          disabled={scale >= maxScale}
+          aria-label={'\u653e\u5927'}
+          title={'\u653e\u5927'}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className="conv-zoomable-viewport__button conv-zoomable-viewport__button--text"
+          onClick={zoomToActualSize}
+          aria-label={'1:1 \u539f\u59cb\u5927\u5c0f'}
+          title={'1:1'}
+        >
+          <Maximize2 className="h-3.5 w-3.5" />
+          1:1
+        </button>
+        <button
+          type="button"
+          className="conv-zoomable-viewport__button conv-zoomable-viewport__button--text"
+          onClick={resetView}
+          aria-label={'\u9002\u5e94'}
+          title={'\u9002\u5e94'}
+        >
+          <Undo2 className="h-3.5 w-3.5" />
+          {'\u9002\u5e94'}
+        </button>
+        <button
+          type="button"
+          className="conv-zoomable-viewport__button conv-zoomable-viewport__button--text"
+          onClick={() => void toggleFullscreen()}
+          aria-label={isFullscreen ? '\u9000\u51fa\u5168\u5c4f' : '\u5168\u5c4f'}
+          title={isFullscreen ? '\u9000\u51fa\u5168\u5c4f' : '\u5168\u5c4f'}
+        >
+          {isFullscreen ? (
+            <Minimize2 className="h-3.5 w-3.5" />
+          ) : (
+            <Maximize2 className="h-3.5 w-3.5" />
+          )}
+          {isFullscreen ? '\u9000\u51fa' : '\u5168\u5c4f'}
+        </button>
+      </div>
+
+      <div
+        ref={viewportRef}
+        className={cn(
+          'conv-zoomable-viewport__stage',
+          canPan
+            ? isDragging
+              ? 'conv-zoomable-viewport__stage--dragging'
+              : 'conv-zoomable-viewport__stage--pannable'
+            : undefined,
+          viewportClassName
+        )}
+        role="img"
+        aria-label={ariaLabel}
+        style={{ touchAction: 'none' }}
+        onWheel={handleWheel}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onDoubleClick={toggleFitOrZoom}
+      >
+        <div
+          className={cn('conv-zoomable-viewport__surface', surfaceClassName)}
+          style={{
+            width: fittedSize.width || undefined,
+            height: fittedSize.height || undefined,
+            transform: `translate(-50%, -50%) translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+
+      <div className="conv-zoomable-viewport__hint" aria-hidden>
+        <ScanSearch className="h-3.5 w-3.5" />
+        <span>{'\u6eda\u8f6e\u7f29\u653e'}</span>
+        <span className="conv-zoomable-viewport__hint-sep">/</span>
+        <span className={canPan ? 'conv-zoomable-viewport__hint-active' : undefined}>
+          {'\u62d6\u62fd\u5e73\u79fb'}
+        </span>
+        {canPan ? (
+          <>
+            <span className="conv-zoomable-viewport__hint-sep">/</span>
+            <Move className="h-3.5 w-3.5" />
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useMermaidDiagram.ts
+++ b/frontend/src/hooks/useMermaidDiagram.ts
@@ -1,0 +1,54 @@
+import { useEffect, useId, useMemo, useState } from 'react';
+import { renderMermaidDiagram } from '@/lib/mermaid/mermaidRuntime';
+import { createMermaidDiagramId } from '@/lib/mermaid/utils';
+import { useMermaidTheme } from '@/hooks/useMermaidTheme';
+
+export type MermaidDiagramState =
+  | { status: 'loading' }
+  | { status: 'ready'; svg: string }
+  | { status: 'error'; message: string };
+
+export function useMermaidDiagram(source: string): MermaidDiagramState {
+  const reactId = useId();
+  const theme = useMermaidTheme();
+  const diagramId = useMemo(
+    () => createMermaidDiagramId(reactId, source),
+    [reactId, source]
+  );
+  const [state, setState] = useState<MermaidDiagramState>({ status: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function renderDiagram() {
+      setState((current) =>
+        current.status === 'ready' ? current : { status: 'loading' }
+      );
+
+      try {
+        const { svg } = await renderMermaidDiagram(diagramId, source, theme);
+        if (!cancelled) {
+          setState({ status: 'ready', svg });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            status: 'error',
+            message:
+              error instanceof Error && error.message
+                ? error.message
+                : '\u672a\u77e5\u7684 Mermaid \u6e32\u67d3\u9519\u8bef',
+          });
+        }
+      }
+    }
+
+    void renderDiagram();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [diagramId, source, theme]);
+
+  return state;
+}

--- a/frontend/src/hooks/useMermaidTheme.ts
+++ b/frontend/src/hooks/useMermaidTheme.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { getMermaidTheme, type MermaidTheme } from '@/lib/mermaid/mermaidRuntime';
+
+export function useMermaidTheme(): MermaidTheme {
+  const [theme, setTheme] = useState(getMermaidTheme);
+
+  useEffect(() => {
+    if (
+      typeof document === 'undefined' ||
+      typeof MutationObserver === 'undefined'
+    ) {
+      return undefined;
+    }
+
+    const root = document.documentElement;
+    const observer = new MutationObserver(() => {
+      setTheme(getMermaidTheme());
+    });
+
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}

--- a/frontend/src/hooks/useZoomableViewport.ts
+++ b/frontend/src/hooks/useZoomableViewport.ts
@@ -1,0 +1,270 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEventHandler,
+  type RefObject,
+  type WheelEventHandler,
+} from 'react';
+
+export type ViewportSize = {
+  width: number;
+  height: number;
+};
+
+export type ViewportOffset = {
+  x: number;
+  y: number;
+};
+
+type DragState = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originX: number;
+  originY: number;
+};
+
+export type ZoomableViewportOptions = {
+  minScale?: number;
+  maxScale?: number;
+  scaleStep?: number;
+  resetKey?: string | number;
+};
+
+const DEFAULT_MIN_SCALE = 1;
+const DEFAULT_MAX_SCALE = 8;
+const DEFAULT_SCALE_STEP = 0.25;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function getContainedSize(content: ViewportSize, viewport: ViewportSize) {
+  if (
+    content.width <= 0 ||
+    content.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return { width: 0, height: 0, fitRatio: 1 };
+  }
+
+  const fitRatio = Math.min(
+    viewport.width / content.width,
+    viewport.height / content.height,
+    1
+  );
+
+  return {
+    width: content.width * fitRatio,
+    height: content.height * fitRatio,
+    fitRatio,
+  };
+}
+
+function clampOffset(
+  offset: ViewportOffset,
+  scale: number,
+  fitted: ViewportSize,
+  viewport: ViewportSize
+) {
+  const scaledWidth = fitted.width * scale;
+  const scaledHeight = fitted.height * scale;
+  const maxOffsetX = Math.max(0, (scaledWidth - viewport.width) / 2);
+  const maxOffsetY = Math.max(0, (scaledHeight - viewport.height) / 2);
+
+  return {
+    x: maxOffsetX === 0 ? 0 : clamp(offset.x, -maxOffsetX, maxOffsetX),
+    y: maxOffsetY === 0 ? 0 : clamp(offset.y, -maxOffsetY, maxOffsetY),
+  };
+}
+
+export function useZoomableViewport(
+  contentSize: ViewportSize,
+  options: ZoomableViewportOptions = {}
+) {
+  const minScale = options.minScale ?? DEFAULT_MIN_SCALE;
+  const maxScale = options.maxScale ?? DEFAULT_MAX_SCALE;
+  const scaleStep = options.scaleStep ?? DEFAULT_SCALE_STEP;
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const [viewportSize, setViewportSize] = useState<ViewportSize>({
+    width: 0,
+    height: 0,
+  });
+  const [scale, setScale] = useState(minScale);
+  const [offset, setOffset] = useState<ViewportOffset>({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+
+  const fittedSize = useMemo(
+    () => getContainedSize(contentSize, viewportSize),
+    [contentSize, viewportSize]
+  );
+  const actualSizeScale = useMemo(
+    () => Math.max(minScale, 1 / fittedSize.fitRatio),
+    [fittedSize.fitRatio, minScale]
+  );
+  const canPan =
+    fittedSize.width * scale > viewportSize.width ||
+    fittedSize.height * scale > viewportSize.height;
+
+  useEffect(() => {
+    setScale(minScale);
+    setOffset({ x: 0, y: 0 });
+    setIsDragging(false);
+    dragStateRef.current = null;
+  }, [minScale, options.resetKey]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return undefined;
+    }
+
+    const updateViewportSize = () => {
+      setViewportSize({
+        width: viewport.clientWidth,
+        height: viewport.clientHeight,
+      });
+    };
+
+    updateViewportSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateViewportSize);
+      return () => window.removeEventListener('resize', updateViewportSize);
+    }
+
+    const observer = new ResizeObserver(updateViewportSize);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    setOffset((currentOffset) =>
+      clampOffset(currentOffset, scale, fittedSize, viewportSize)
+    );
+  }, [fittedSize, scale, viewportSize]);
+
+  const applyScale = (nextScale: number, anchor?: ViewportOffset) => {
+    const normalizedScale = clamp(nextScale, minScale, maxScale);
+
+    if (
+      normalizedScale === minScale ||
+      fittedSize.width === 0 ||
+      fittedSize.height === 0
+    ) {
+      setScale(minScale);
+      setOffset({ x: 0, y: 0 });
+      return;
+    }
+
+    if (!anchor) {
+      setScale(normalizedScale);
+      setOffset((currentOffset) =>
+        clampOffset(currentOffset, normalizedScale, fittedSize, viewportSize)
+      );
+      return;
+    }
+
+    const nextOffset = {
+      x: anchor.x - ((anchor.x - offset.x) / scale) * normalizedScale,
+      y: anchor.y - ((anchor.y - offset.y) / scale) * normalizedScale,
+    };
+
+    setScale(normalizedScale);
+    setOffset(clampOffset(nextOffset, normalizedScale, fittedSize, viewportSize));
+  };
+
+  const resetView = () => {
+    setScale(minScale);
+    setOffset({ x: 0, y: 0 });
+  };
+
+  const zoomIn = () => applyScale(scale + scaleStep);
+  const zoomOut = () => applyScale(scale - scaleStep);
+  const zoomToActualSize = () => applyScale(actualSizeScale);
+  const toggleFitOrZoom = () =>
+    applyScale(scale > minScale ? minScale : Math.min(actualSizeScale, 2));
+
+  const handleWheel: WheelEventHandler<HTMLDivElement> = (event) => {
+    if (fittedSize.width === 0 || fittedSize.height === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const anchor = {
+      x: event.clientX - rect.left - rect.width / 2,
+      y: event.clientY - rect.top - rect.height / 2,
+    };
+    const direction = event.deltaY < 0 ? 1 : -1;
+    applyScale(scale + direction * scaleStep, anchor);
+  };
+
+  const handlePointerDown: PointerEventHandler<HTMLDivElement> = (event) => {
+    if (!canPan) {
+      return;
+    }
+
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: offset.x,
+      originY: offset.y,
+    };
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove: PointerEventHandler<HTMLDivElement> = (event) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const nextOffset = {
+      x: dragState.originX + (event.clientX - dragState.startX),
+      y: dragState.originY + (event.clientY - dragState.startY),
+    };
+    setOffset(clampOffset(nextOffset, scale, fittedSize, viewportSize));
+  };
+
+  const handlePointerEnd: PointerEventHandler<HTMLDivElement> = (event) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    dragStateRef.current = null;
+    setIsDragging(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  return {
+    viewportRef: viewportRef as RefObject<HTMLDivElement>,
+    fittedSize,
+    scale,
+    offset,
+    canPan,
+    isDragging,
+    zoomPercent: Math.round(scale * 100),
+    zoomIn,
+    zoomOut,
+    zoomToActualSize,
+    resetView,
+    toggleFitOrZoom,
+    handleWheel,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerEnd,
+    minScale,
+    maxScale,
+  };
+}

--- a/frontend/src/lib/mermaid/mermaidRuntime.ts
+++ b/frontend/src/lib/mermaid/mermaidRuntime.ts
@@ -1,0 +1,72 @@
+import { buildMermaidRenderCandidates } from './normalizeMermaidSource';
+
+export type MermaidTheme = 'default' | 'dark';
+
+const MERMAID_FONT_FAMILY =
+  'Noto Sans SC Variable, Source Han Sans SC, Source Han Sans CN, Noto Sans CJK SC, Noto Sans SC, 思源黑体, sans-serif';
+
+let lastMermaidTheme: MermaidTheme | null = null;
+
+export function getMermaidTheme(): MermaidTheme {
+  if (typeof document === 'undefined') {
+    return 'default';
+  }
+
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'default';
+}
+
+async function loadMermaid(theme: MermaidTheme) {
+  const { default: mermaid } = await import('mermaid');
+  if (lastMermaidTheme !== theme) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      theme,
+      fontFamily: MERMAID_FONT_FAMILY,
+      maxTextSize: 100_000,
+      flowchart: {
+        htmlLabels: true,
+        useMaxWidth: true,
+      },
+      sequence: {
+        useMaxWidth: true,
+      },
+      er: {
+        useMaxWidth: true,
+      },
+      gantt: {
+        useMaxWidth: true,
+      },
+      journey: {
+        useMaxWidth: true,
+      },
+    });
+    lastMermaidTheme = theme;
+  }
+  return mermaid;
+}
+
+export async function renderMermaidDiagram(
+  diagramId: string,
+  source: string,
+  theme: MermaidTheme
+): Promise<{ svg: string; source: string }> {
+  const mermaid = await loadMermaid(theme);
+  const candidates = buildMermaidRenderCandidates(source);
+  let lastError: unknown;
+
+  for (const [index, candidate] of candidates.entries()) {
+    try {
+      const renderId =
+        index === 0 ? diagramId : `${diagramId}-fallback-${index}`;
+      const { svg } = await mermaid.render(renderId, candidate);
+      return { svg, source: candidate };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Mermaid render failed');
+}

--- a/frontend/src/lib/mermaid/normalizeMermaidSource.test.ts
+++ b/frontend/src/lib/mermaid/normalizeMermaidSource.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMermaidRenderCandidates,
+  normalizeMermaidSource,
+} from './normalizeMermaidSource';
+
+describe('normalizeMermaidSource', () => {
+  it('converts graph directives to flowchart', () => {
+    expect(normalizeMermaidSource('graph TB\nA-->B')).toBe(
+      'flowchart TB\nA-->B'
+    );
+  });
+
+  it('quotes unquoted subgraph titles', () => {
+    expect(normalizeMermaidSource('flowchart TB\nsubgraph 基础层\nA-->B\nend')).toBe(
+      'flowchart TB\nsubgraph 基础层["基础层"]\nA-->B\nend'
+    );
+  });
+
+  it('removes list markers after line breaks in node labels', () => {
+    expect(
+      normalizeMermaidSource(
+        'flowchart TB\nBM[BaseModel<br/>- ID, CreatedAt<br/>- UpdatedAt]'
+      )
+    ).toBe(
+      'flowchart TB\nBM["BaseModel<br/>ID, CreatedAt<br/>UpdatedAt"]'
+    );
+  });
+
+  it('quotes complex node labels with commas', () => {
+    expect(normalizeMermaidSource('flowchart TB\nBM[BaseModel, ID, Name]')).toBe(
+      'flowchart TB\nBM["BaseModel, ID, Name"]'
+    );
+  });
+
+  it('deduplicates render candidates when normalization is a no-op', () => {
+    expect(buildMermaidRenderCandidates('flowchart TB\nA-->B')).toEqual([
+      'flowchart TB\nA-->B',
+    ]);
+  });
+
+  it('includes normalized fallback when source changes', () => {
+    expect(buildMermaidRenderCandidates('graph TB\nsubgraph RBAC\nA-->B\nend')).toEqual([
+      'graph TB\nsubgraph RBAC\nA-->B\nend',
+      'flowchart TB\nsubgraph RBAC["RBAC"]\nA-->B\nend',
+    ]);
+  });
+});

--- a/frontend/src/lib/mermaid/normalizeMermaidSource.ts
+++ b/frontend/src/lib/mermaid/normalizeMermaidSource.ts
@@ -1,0 +1,58 @@
+type MermaidTransform = (source: string) => string;
+
+function pipe(...transforms: MermaidTransform[]): MermaidTransform {
+  return (source) => transforms.reduce((current, transform) => transform(current), source);
+}
+
+import { hashString } from './utils';
+
+function slugifyLabel(value: string): string {
+  const slug = value
+    .trim()
+    .replace(/[^\w\u4e00-\u9fff-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return slug || `sg_${hashString(value)}`;
+}
+
+const prepareSource = pipe(
+  (value) => value.replace(/\r\n?/g, '\n').replace(/^\uFEFF/, ''),
+  (value) => value.trim()
+);
+
+const applyCompatibilityFixes = pipe(
+  (value) => value.replace(/^(\s*)graph(\s+|$)/im, '$1flowchart$2'),
+  (value) =>
+    value.replace(/^(\s*subgraph\s+)(.+)$/gm, (line, prefix: string, titlePart: string) => {
+      const trimmed = titlePart.trim();
+      if (!trimmed || /^[\w-]+\s*\[/.test(trimmed) || /^"[^"]*"$/.test(trimmed)) {
+        return line;
+      }
+
+      const id = slugifyLabel(trimmed);
+      const escapedTitle = trimmed.replace(/"/g, '#quot;');
+      return `${prefix}${id}["${escapedTitle}"]`;
+    }),
+  (value) =>
+    value
+      .replace(/<br\s*\/?>\s*-\s+/gi, '<br/>')
+      .replace(/(\[[^\]]*?)<br\s*\/?>\s*-\s+/gi, '$1<br/>'),
+  (value) =>
+    value.replace(/(\b[\w-]+)\[([^\]"\n]+)\]/g, (match, nodeId: string, label: string) => {
+      if (label.includes('"')) return match;
+      if (!/[<,;:]/.test(label) && !label.includes('<br')) return match;
+      const escaped = label.replace(/"/g, '#quot;');
+      return `${nodeId}["${escaped}"]`;
+    })
+);
+
+export function normalizeMermaidSource(value: string): string {
+  return applyCompatibilityFixes(prepareSource(value));
+}
+
+export function buildMermaidRenderCandidates(value: string): string[] {
+  const prepared = prepareSource(value);
+  if (!prepared) return [''];
+
+  const normalized = normalizeMermaidSource(prepared);
+  return normalized === prepared ? [prepared] : [prepared, normalized];
+}

--- a/frontend/src/lib/mermaid/utils.ts
+++ b/frontend/src/lib/mermaid/utils.ts
@@ -1,0 +1,16 @@
+export function hashString(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+export function sanitizeDomId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '') || 'diagram';
+}
+
+export function createMermaidDiagramId(reactId: string, source: string): string {
+  return `mermaid-${sanitizeDomId(reactId)}-${hashString(source)}`;
+}

--- a/frontend/src/styles/conversation/conv-markdown.css
+++ b/frontend/src/styles/conversation/conv-markdown.css
@@ -260,14 +260,156 @@
   background: var(--conv-surface-control);
 }
 
-.conv-md-mermaid-image {
+.conv-md-mermaid-viewport {
+  min-height: 220px;
+  max-height: min(70vh, 720px);
+  border-top: 1px solid var(--conv-border-subtle);
+}
+
+.conv-md-mermaid-viewer {
+  position: relative;
+}
+
+.conv-md-mermaid-surface {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.conv-md-mermaid-svg,
+.conv-md-mermaid-svg svg {
   display: block;
   width: 100%;
-  max-width: 100%;
-  max-height: 420px;
-  object-fit: contain;
-  padding: 12px;
+  height: 100%;
+  max-width: none;
+}
+
+.conv-zoomable-viewport {
+  position: relative;
   background: var(--conv-surface-card);
+}
+
+.conv-zoomable-viewport[data-fullscreen='true'] {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--conv-surface-card);
+}
+
+.conv-zoomable-viewport[data-fullscreen='true'] .conv-zoomable-viewport__stage {
+  max-height: none;
+  flex: 1;
+}
+
+.conv-zoomable-viewport__toolbar {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--conv-border-subtle);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--conv-surface-card) 92%, transparent);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.08));
+  backdrop-filter: blur(8px);
+}
+
+.conv-zoomable-viewport__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 6px;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  color: var(--conv-text-secondary);
+  background: transparent;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.conv-zoomable-viewport__button:hover:not(:disabled) {
+  color: var(--conv-text-primary);
+  background: var(--conv-surface-control);
+}
+
+.conv-zoomable-viewport__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.conv-zoomable-viewport__button--text {
+  padding-inline: 8px;
+}
+
+.conv-zoomable-viewport__zoom {
+  min-width: 3rem;
+  padding-inline: 2px;
+  color: var(--conv-text-primary);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+  user-select: none;
+}
+
+.conv-zoomable-viewport__stage {
+  position: relative;
+  overflow: hidden;
+  min-height: inherit;
+  max-height: inherit;
+  background: var(--conv-surface-card);
+}
+
+.conv-zoomable-viewport__stage--pannable {
+  cursor: grab;
+}
+
+.conv-zoomable-viewport__stage--dragging {
+  cursor: grabbing;
+}
+
+.conv-zoomable-viewport__surface {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: center center;
+}
+
+.conv-zoomable-viewport__hint {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--conv-border-subtle);
+  border-radius: var(--radius);
+  color: var(--conv-text-tertiary);
+  background: color-mix(in srgb, var(--conv-surface-card) 90%, transparent);
+  font-size: 11px;
+  pointer-events: none;
+  backdrop-filter: blur(8px);
+}
+
+.conv-zoomable-viewport__hint-sep {
+  color: var(--conv-text-tertiary);
+  opacity: 0.5;
+}
+
+.conv-zoomable-viewport__hint-active {
+  color: var(--conv-text-secondary);
 }
 
 .conv-md-mermaid-error {


### PR DESCRIPTION
## Summary
- Add Mermaid source normalization (graph→flowchart, subgraph quoting, complex label fixes) with render fallback
- Render diagrams as inline SVG with zoom, pan, fit, 1:1, and fullscreen preview
- Extract reusable zoomable viewport and Mermaid runtime modules
Closes #10
## Test plan
- [x] `pnpm exec vitest run src/lib/mermaid/normalizeMermaidSource.test.ts`
- [x] `pnpm exec vitest run src/components/NormalizedConversation/Markdown.test.tsx -t "Mermaid|mermaid|normalize"`
- [x] `pnpm run check`